### PR TITLE
Fixed map behavior when clicking on an entry from the changes/data page

### DIFF
--- a/src/main/primary_entry/script/page/map/action/PanZoomAction.js
+++ b/src/main/primary_entry/script/page/map/action/PanZoomAction.js
@@ -9,8 +9,7 @@ export default class PanZoomAction {
     }
 
     zoomToLocation(event, data) {
-        this.mapApi.setZoom(data.zoom);
-        this.mapApi.setView(data.latLng);
+        this.mapApi.setView(data.latLng, data.zoom);
     };
 
 };

--- a/src/main/primary_entry/script/page/map/action/ShowSiteAction.js
+++ b/src/main/primary_entry/script/page/map/action/ShowSiteAction.js
@@ -38,7 +38,10 @@ export default class ShowSiteAction {
                  * in response to viewport changes on the map. */
                 $.doTimeout(75, () => {
                     if (supercharger && supercharger.marker) {
-                        supercharger.marker.fire('click');
+                        if (!supercharger.marker.infoWindow || !supercharger.marker.infoWindow.isShown()) {
+                            // Do not remove popup if it exists
+                            supercharger.marker.fire('click');
+                        }
                         return false;
                     }
                     else {


### PR DESCRIPTION
When the zoom level is not set to 10 (default) and a user clicks an entry on the changes or data pages, the maps page updates the zoom but fails to pan correctly. This pull request fixes that, and also only shows the infobox/popup upon clicking a site entry on one of those tabs (instead of toggling it which would cause the infobox to disappear if it was previously shown).