### PR TITLE
Link to this view fix

### DIFF
--- a/src/main/primary_entry/script/page/map/action/CreateLinkAction.js
+++ b/src/main/primary_entry/script/page/map/action/CreateLinkAction.js
@@ -20,7 +20,7 @@ Action.prototype.createLink = function (event) {
     const zoom = this.mapApi.getZoom();
     const latLng = this.getCenter();
     let linkStr = window.location.href.split('?')[0];
-    linkStr += '?Center=' + latLng.toString() + '&Zoom=' + zoom;
+    linkStr += '?Center=' + latLng.lat + ',' + latLng.lng + '&Zoom=' + zoom;
     if (rangeModel.getRangeMeters() !== 0) {
         if (rangeModel.displayUnit.isKilometers()) {
             linkStr += '&RangeKm=' + rangeModel.getCurrent();


### PR DESCRIPTION
Using `.toString()` on a [`LatLng` object](https://leafletjs.com/reference-1.7.1.html#latlng) builds a text-based constructor call of the object. When building a permalink, we need plain GPS coordinates instead.

Note: ~~I submitted this with the web editor because I'm pretty confident in it, but it does need basic testing first and then we should be good to go.~~ **Tested the modification just now, all looks good.**