### PR TITLE
Fixed username link when logged in to have normal font

### DIFF
--- a/src/main/primary_entry/script/nav/NavBarUserDropdown.js
+++ b/src/main/primary_entry/script/nav/NavBarUserDropdown.js
@@ -50,7 +50,7 @@ export default class NavBarUserDropdown {
         this.loginLink.hide();
 
         $("#username-link").html(
-            `<span class='glyphicon glyphicon-user' aria-hidden='true'/> ${data.username} <span class='caret'/>`
+            `<span class='glyphicon glyphicon-user' aria-hidden='true'></span> ${data.username} <span class='caret'/>`
         ).show();
 
         $("#save-route-trigger").show();


### PR DESCRIPTION
Changed self-closing span to have a closing tag. For whatever reason, it really wasn't self-closing and included the username and caret icon as its children, causing the username to have the Glyphicons font and appear out of place.