### PR TITLE
Fix missing marker when searching

### DIFF
--- a/src/main/primary_entry/script/page/map/MapView.js
+++ b/src/main/primary_entry/script/page/map/MapView.js
@@ -37,6 +37,15 @@ export default class MapView {
         this.mapApi.on('moveend', $.proxy(this.handleViewportChange, this));
         // draw map for first time.
         this.handleViewportChange();
+
+        // fixes leaflet and webpack not playing nice
+        // https://github.com/PaulLeCam/react-leaflet/issues/453#issuecomment-761806673
+        delete L.Icon.Default.prototype._getIconUrl;
+        L.Icon.Default.mergeOptions({
+            iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+            iconUrl: require('leaflet/dist/images/marker-icon.png'),
+            shadowUrl: require('leaflet/dist/images/marker-shadow.png')
+        });
     }
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Issue was that leaflet and webpack weren't playing nice as detailed here: https://github.com/PaulLeCam/react-leaflet/issues/453#issuecomment-761806673

Now the search marker shows properly:
![Blue Image Marker](https://user-images.githubusercontent.com/1804643/179149384-044680a5-aaab-4e2f-b780-6b0b12350a26.png)
