### PR TITLE
New disclaimer language from Tesla legal

### DIFF
--- a/src/main/primary_entry/html/index.html
+++ b/src/main/primary_entry/html/index.html
@@ -400,7 +400,7 @@ PAGE: about
     </p>
     <br/>
     <p>
-    Supercharge.info is not produced by Tesla. Related sites from Tesla:
+    Information on supercharge.info is neither provided nor validated by Tesla and we cannot confirm the accuracy of the information provided. For up to date and correct information on the Supercharger network please refer to the following sites from Tesla:
 
     <table class="table table-condensed table-bordered">
         <tr>


### PR DESCRIPTION
In November 2021 I received the following via email from a representative of Tesla's legal team:

> Dear Mr. Wright,
> 
> We recently came across your website, https://supercharge.info/charts.  We notice that the information contained in this website is inaccurate.   Since you are not affiliated with Tesla, we request that you add the following disclaimer to your site:
> 
> Information on Supercharge.info is neither provided nor validated by Tesla and we cannot confirm the accuracy of the information provided. For up to date and correct information on the Supercharger network please refer to the following sites from Tesla:  (your current links are acceptable)
> 
> If you are unwilling to add the disclaimer, we request that the website be removed immediately.
> 
> Please confirm via return email that you will add this disclaimer or remove the site.

I manually applied the change at that time, but this pull request is to commit it to the repository.