### PR TITLE
Add other social media accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supercharge.info",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "map",
   "scripts": {
     "build": "echo use 'npm run prodbuild' or 'npm run devbuild'",

--- a/src/main/primary_entry/html/index.html
+++ b/src/main/primary_entry/html/index.html
@@ -520,15 +520,48 @@ PAGE: about
     </p>
     <br/>
     <p>
-        View our <b><a id="features-dialog-trigger" href="#" data-toggle="modal" data-target="#features-dialog">latest feature updates</a></b>,
-        and follow <a href="https://twitter.com/superchargeinfo" target="_blank"><b>@superchargeinfo</b> on Twitter</a>.
+        View our <b><a id="features-dialog-trigger" href="#" data-toggle="modal" data-target="#features-dialog">latest feature updates</a></b>.
     </p>
-    <p></p><p></p>
+    <br/>
     <p>
-    <a href="https://www.patreon.com/supercharge_info" target="_blank">
-        <img style="max-height: 3em" src="images/become_a_patron_button@2x.png" alt="Become A Patron"/>
-    </a>
+        <a href="https://www.patreon.com/supercharge_info" target="_blank">
+            <img style="max-height: 3em" src="images/become_a_patron_button@2x.png" alt="Become A Patron"/>
+        </a>
     </p>
+
+    <br/>
+    <h3 class="margin-top">supercharge.info on Social Media</h3>
+    <table class="table table-bordered" style="width: 50%;">
+      <tbody>
+        <tr>
+          <td>X</td>
+          <td>
+            <a href="https://x.com/superchargeinfo" target="_blank">@superchargeinfo</a>,
+            <a href="https://x.com/superchargefeed" target="_blank">@superchargefeed</a>
+          </td>
+        </tr>
+        <tr>
+          <td>Bluesky</td>
+          <td>
+            <a href="https://bsky.app/profile/supercharge.info" target="_blank">@supercharge.info</a>,
+            <a href="https://bsky.app/profile/changes.supercharge.info" target="_blank">@changes.supercharge.info</a>
+          </td>
+        </tr>
+        <tr>
+          <td>Mastodon</td>
+          <td>
+            <a href="https://mastodon.social/@superchargeinfo" target="_blank">@superchargeinfo@mastodon.social</a>
+          </td>
+        </tr>
+        <tr>
+          <td>Instagram</td>
+          <td>
+            <a href="https://www.instagram.com/superchargeinfo/" target="_blank">@superchargeinfo</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
     <br/>
     <p>
     Information on supercharge.info is neither provided nor validated by Tesla and we cannot guarantee the accuracy of the information provided.<br/>


### PR DESCRIPTION
Adding Bluesky, Instagram, and Mastodon profiles to the About page.